### PR TITLE
Release v3

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,5 +30,12 @@
 		"assert_equal",
 		"sys",
 		"html5"
-	]
+	],
+	"Lua.format.defaultConfig": {
+		"tab_width": "4",
+		"max_line_length": "140",
+		"line_space_after_function_statement": "fixed(3)",
+		"indent_style": "tab",
+		"indent_size": "4"
+	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,7 +29,8 @@
 		"socket",
 		"assert_equal",
 		"sys",
-		"html5"
+		"html5",
+		"defold_saver"
 	],
 	"Lua.format.defaultConfig": {
 		"tab_width": "4",

--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@
 
 Open your `game.project` file and add the following line to the dependencies field under the project section:
 
-**[Saver](https://github.com/Insality/defold-saver/archive/refs/tags/2.zip)**
+**[Saver](https://github.com/Insality/defold-saver/archive/refs/tags/3.zip)**
 
 ```
-https://github.com/Insality/defold-saver/archive/refs/tags/2.zip
+https://github.com/Insality/defold-saver/archive/refs/tags/3.zip
 ```
 
 After that, select `Project ▸ Fetch Libraries` to update [library dependencies]((https://defold.com/manuals/libraries/#setting-up-library-dependencies)). This happens automatically whenever you open a project so you will only need to do this if the dependencies change without re-opening the project.
@@ -59,7 +59,7 @@ storage_key = storage
 This configuration section for `game.project` defines various settings:
 
 - **save_name**: The name of the save file. Default is `game.json`.
-- **save_folder**: The folder name where the save file will be stored. Default is your `project.title` name.
+- **save_folder**: The folder name where the save file will be stored. Default is your `project.title` name (with only alphanumeric, underscores or spaces characters).
 - **autosave_timer**: The time interval in seconds between auto-saves. Default is `3`.
 - **saver_key**: The key in the save data table that contains the Saver state. Default is `saver`.
 - **storage_key**: The key in the save data table that contains the Storage state. Default is `storage`.
@@ -171,8 +171,10 @@ For any issues, questions, or suggestions, please [create an issue](https://gith
 	- Add `saver.before_save_callback` callback for custom save logic. Can be used to prepare/update data before saving, like transfing from real-time data to save data
 
 ### **V3**
-From this version a save folder taken differently from your project title, you can configure it in `game.project` file to match your previous save folder.
+	- BREAKING: HTML5 data now using `sys.serialize` instead `json.encode` due the issue with `json.encode` (sparse arrays, number keys)
+	- BREAKING: Change the way to get the project file name. Now it's removing the spaces and special characters from the project title. To get the previous behavior, you should set the `save_folder` in the `game.project` file.
 	- Add `saver.save_folder` configuration option to README.md.
+	- Fix `saver.delete_file_by_path` for HTML5.
 </details>
 
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You should configure the module in the `game.project` file:
 ```ini
 [saver]
 save_name = game.json
+save_folder = Defold Saver
 autosave_timer = 3
 saver_key = saver
 storage_key = storage
@@ -58,6 +59,7 @@ storage_key = storage
 This configuration section for `game.project` defines various settings:
 
 - **save_name**: The name of the save file. Default is `game.json`.
+- **save_folder**: The folder name where the save file will be stored. Default is your `project.title` name.
 - **autosave_timer**: The time interval in seconds between auto-saves. Default is `3`.
 - **saver_key**: The key in the save data table that contains the Saver state. Default is `saver`.
 - **storage_key**: The key in the save data table that contains the Storage state. Default is `storage`.
@@ -167,6 +169,10 @@ For any issues, questions, or suggestions, please [create an issue](https://gith
 	- Update docs, missing API for saver.delete_* functions
 	- Fix error with `get_current_game_project_folder` while using in HTML5 builds
 	- Add `saver.before_save_callback` callback for custom save logic. Can be used to prepare/update data before saving, like transfing from real-time data to save data
+
+### **V3**
+From this version a save folder taken differently from your project title, you can configure it in `game.project` file to match your previous save folder.
+	- Add `saver.save_folder` configuration option to README.md.
 </details>
 
 

--- a/game.project
+++ b/game.project
@@ -23,6 +23,7 @@ include_dirs = saver
 
 [saver]
 save_name = game.json
+save_folder = Defold Saver
 autosave_timer = 0
 saver_key = saver
 storage_key = storage

--- a/saver/ext.manifest
+++ b/saver/ext.manifest
@@ -1,0 +1,1 @@
+name: "DefoldSaver"

--- a/saver/saver.lua
+++ b/saver/saver.lua
@@ -12,7 +12,7 @@ local migrations = require("saver.migrations")
 local saver_internal = require("saver.saver_internal")
 
 local PROJECT_NAME = sys.get_config_string("project.title")
-local DIRECTORY_PATH = sys.get_config_string("saver.save_folder", PROJECT_NAME)
+local DIRECTORY_PATH = sys.get_config_string("saver.save_folder", PROJECT_NAME):gsub("%W", "")
 local SAVE_NAME = sys.get_config_string("saver.save_name", "game")
 local SAVER_KEY = sys.get_config_string("saver.saver_key", "saver")
 local STORAGE_KEY = sys.get_config_string("saver.storage_key", "storage")

--- a/saver/saver.lua
+++ b/saver/saver.lua
@@ -11,8 +11,9 @@ local storage = require("saver.storage")
 local migrations = require("saver.migrations")
 local saver_internal = require("saver.saver_internal")
 
-local PROJECT_NAME = sys.get_config_string("project.title")
-local DIRECTORY_PATH = sys.get_config_string("saver.save_folder", PROJECT_NAME):gsub("%W", "")
+--- Take a default folder name as a project name without special characters
+local PROJECT_NAME = sys.get_config_string("project.title"):gsub("[^%w_ ]", "")
+local DIRECTORY_PATH = sys.get_config_string("saver.save_folder", PROJECT_NAME)
 local SAVE_NAME = sys.get_config_string("saver.save_name", "game")
 local SAVER_KEY = sys.get_config_string("saver.saver_key", "saver")
 local STORAGE_KEY = sys.get_config_string("saver.storage_key", "storage")

--- a/saver/saver.lua
+++ b/saver/saver.lua
@@ -143,7 +143,7 @@ end
 ---Load and override the table_reference. The reference on the table keeps the same
 ---@param table_key_id string The save state id to save
 ---@param table_reference table The save state table
----@return table The table_reference
+---@return table table_reference The table_reference
 function M.bind_save_state(table_key_id, table_reference)
 	local save_table = M.get_game_state()
 	assert(save_table, "Add save part should be called after init")

--- a/saver/saver.lua
+++ b/saver/saver.lua
@@ -105,7 +105,8 @@ function M.load_game_state(save_name)
 end
 
 
----Delete the game state
+---Delete the game state file. Doesn't affect the current game state
+---If autosave is enabled, it will be rescheduled, so probably you want to immediately restart the game
 ---@param save_name string|nil @The save name. If not passed, will use default from settings
 ---@return boolean
 function M.delete_game_state(save_name)

--- a/saver/saver.lua
+++ b/saver/saver.lua
@@ -117,7 +117,7 @@ function M.delete_game_state(save_name)
 	if is_success then
 		saver_internal.logger:info("Delete game state", { save_name = save_name, path = path })
 	else
-		saver_internal.logger:error("Can't delete the file", { save_name = save_name, path = path })
+		saver_internal.logger:info("File not exists to remove", { save_name = save_name, path = path })
 	end
 
 	return is_success

--- a/saver/saver.lua
+++ b/saver/saver.lua
@@ -186,7 +186,7 @@ end
 ---@param path string
 ---@return boolean
 function M.delete_file_by_path(path)
-	return os.remove(path)
+	return saver_internal.delete_by_path(path)
 end
 
 

--- a/saver/saver_internal.lua
+++ b/saver/saver_internal.lua
@@ -37,6 +37,8 @@ function M.reset_state()
 		migration_version = 0,
 	}
 end
+
+
 M.reset_state()
 
 
@@ -246,7 +248,7 @@ function M.table_to_lua_string(tbl, indent, is_array)
 end
 
 
-local GET_LOCAL_STORAGE =  [[
+local GET_LOCAL_STORAGE = [[
 (function() {
 	try {
 		return window.localStorage.getItem('%s') || '{}';
@@ -269,7 +271,7 @@ function M.load_html5(path)
 end
 
 
-local SET_LOCAL_STORAGE =  [[
+local SET_LOCAL_STORAGE = [[
 (function() {
 	try {
 		window.localStorage.setItem('%s','%s');

--- a/saver/saver_internal.lua
+++ b/saver/saver_internal.lua
@@ -147,6 +147,18 @@ function M.load_by_path(filepath)
 end
 
 
+---Remove file by path
+---@param filepath string The file path
+---@return boolean true if the file was removed successfully, false otherwise
+function M.delete_by_path(filepath)
+	if html5 then
+		M.delete_html5(filepath)
+	end
+
+	return os.remove(filepath)
+end
+
+
 ---Save the data in save directory
 ---@param data table The save data table
 ---@param filepath string The save file path in save directory
@@ -293,6 +305,26 @@ function M.save_html5(data, path)
 	local is_save_successful = html5.run(string.format(SET_LOCAL_STORAGE, path, encoded_data))
 
 	return (not not is_save_successful)
+end
+
+
+local REMOVE_LOCAL_STORAGE = [[
+(function() {
+	try {
+		window.localStorage.removeItem('%s');
+		return true;
+	} catch(e) {
+		return false;
+	}
+})()
+]]
+
+---Remove the data from the local storage in HTML5
+---@param path string The path to the data in the local storage
+---@return boolean true if the data was removed successfully, false otherwise
+function M.delete_html5(path)
+	local is_delete_successful = html5.run(string.format(REMOVE_LOCAL_STORAGE, path))
+	return (not not is_delete_successful)
 end
 
 

--- a/saver/src/defold_saver.cpp
+++ b/saver/src/defold_saver.cpp
@@ -1,0 +1,72 @@
+#define LIB_NAME "DefoldSaver"
+#define MODULE_NAME "defold_saver"
+
+#include <dmsdk/sdk.h>
+#include <dmsdk/dlib/crypt.h>
+
+// Source: https://github.com/defold/extension-crypt/blob/master/crypt/src/crypt.cpp
+// Inline this two functions to avoid linking with the extension-crypt library
+
+static int Crypt_Base64Encode(lua_State* L) {
+	DM_LUA_STACK_CHECK(L, 1);
+
+	size_t srclen;
+	const char* src = luaL_checklstring(L, 1, &srclen);
+
+	// 4 characters to represent every 3 bytes with padding applied
+	// for binary data which isn't an exact multiple of 3 bytes.
+	// https://stackoverflow.com/a/7609180/1266551
+	uint32_t dstlen = srclen * 4 / 3 + 4;
+	uint8_t* dst = (uint8_t*)malloc(dstlen);
+
+	if (dmCrypt::Base64Encode((const uint8_t*)src, srclen, dst, &dstlen)) {
+		lua_pushlstring(L, (char*)dst, dstlen);
+	} else {
+		lua_pushnil(L);
+	}
+
+	free(dst);
+	return 1;
+}
+
+static int Crypt_Base64Decode(lua_State* L) {
+	DM_LUA_STACK_CHECK(L, 1);
+
+	size_t srclen;
+	const char* src = luaL_checklstring(L, 1, &srclen);
+
+	uint32_t dstlen = srclen * 3 / 4;
+	uint8_t* dst = (uint8_t*)malloc(dstlen);
+
+	if (dmCrypt::Base64Decode((const uint8_t*)src, srclen, dst, &dstlen)) {
+		lua_pushlstring(L, (char*)dst, dstlen);
+	} else {
+		lua_pushnil(L);
+	}
+
+	free(dst);
+	return 1;
+}
+
+// Functions exposed to Lua
+static const luaL_reg Module_methods[] = {
+	{"encode_base64", Crypt_Base64Encode},
+	{"decode_base64", Crypt_Base64Decode},
+	{0, 0}
+};
+
+static void LuaInit(lua_State* L) {
+	int top = lua_gettop(L);
+
+	luaL_register(L, MODULE_NAME, Module_methods);
+	lua_pop(L, 1);
+
+	assert(top == lua_gettop(L));
+}
+
+static dmExtension::Result Initialize(dmExtension::Params* params) {
+	LuaInit(params->m_L);
+	return dmExtension::RESULT_OK;
+}
+
+DM_DECLARE_EXTENSION(DefoldSaver, LIB_NAME, 0, 0, Initialize, 0, 0, 0)


### PR DESCRIPTION
- **BREAKING**: HTML5 data now using `sys.serialize` instead `json.encode` due the issue with `json.encode` (sparse arrays, number keys)
- **BREAKING**: Change the way to get the project file name. Now it's removing the spaces and special characters from the project title. To get the previous behavior, you should set the `save_folder` in the `game.project` file.
- Add `saver.save_folder` configuration option to README.md.
- Fix `saver.delete_file_by_path` for HTML5.